### PR TITLE
Transformer now adds environmentProperties to TaskLaunchRequest

### DIFF
--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/README.adoc
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/README.adoc
@@ -25,18 +25,18 @@ A  byte array containing the `TaskLaunchRequest`
 The **$$tasklaunchrequest$$** $$processor$$ has the following options:
 
 //tag::configuration-properties[]
-$$application-name$$:: $$The name to be applied to the launched task.$$ *($$String$$, default: `$$<empty string>$$`)*
-$$command-line-arguments$$:: $$Space delimited list of commandLineArguments to be applied to the
+$$task.launch.request.application-name$$:: $$The name to be applied to the launched task.$$ *($$String$$, default: `$$<empty string>$$`)*
+$$task.launch.request.command-line-arguments$$:: $$Space delimited list of commandLineArguments to be applied to the
   TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$data-source-driver-class-name$$:: $$The datasource driver class name to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$data-source-password$$:: $$The datasource password to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$data-source-url$$:: $$The datasource url to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$data-source-user-name$$:: $$The datasource user name to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$deployment-properties$$:: $$Comma delimited list of deployment properties to be applied to the
+$$task.launch.request.data-source-driver-class-name$$:: $$The datasource driver class name to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$task.launch.request.data-source-password$$:: $$The datasource password to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$task.launch.request.data-source-url$$:: $$The datasource url to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$task.launch.request.data-source-user-name$$:: $$The datasource user name to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$task.launch.request.deployment-properties$$:: $$Comma delimited list of deployment properties to be applied to the
  TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$environment-properties$$:: $$Comma delimited list of environment properties to be applied to the
+$$task.launch.request.environment-properties$$:: $$Comma delimited list of environment properties to be applied to the
  TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
-$$uri$$:: $$The uri of the artifact to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$task.launch.request.uri$$:: $$The uri of the artifact to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
 == Building with Maven

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/README.adoc
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/README.adoc
@@ -34,6 +34,8 @@ $$data-source-url$$:: $$The datasource url to be applied to the TaskLaunchReques
 $$data-source-user-name$$:: $$The datasource user name to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
 $$deployment-properties$$:: $$Comma delimited list of deployment properties to be applied to the
  TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
+$$environment-properties$$:: $$Comma delimited list of environment properties to be applied to the
+ TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
 $$uri$$:: $$The uri of the artifact to be applied to the TaskLaunchRequest.$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/pom.xml
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/pom.xml
@@ -18,7 +18,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-stream</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/pom.xml
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/pom.xml
@@ -18,6 +18,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-stream</artifactId>
+			<version>2.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
@@ -26,9 +26,10 @@ import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.task.launcher.TaskLaunchRequest;
-import org.springframework.integration.annotation.Transformer;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -57,7 +58,8 @@ public class TasklaunchrequestTransformProcessorConfiguration {
 	@Autowired
 	private TasklaunchrequestTransformProcessorProperties processorProperties;
 
-	@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+	@StreamListener(Processor.INPUT)
+	@SendTo(Processor.OUTPUT)
 	public Object setupRequest(String data) throws Exception{
 		Map<String, String> properties = new HashMap<String, String>();
 		Map<String, String> deploymentProperties = null;

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
@@ -29,6 +29,8 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.task.launcher.TaskLaunchRequest;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -58,9 +60,10 @@ public class TasklaunchrequestTransformProcessorConfiguration {
 	@Autowired
 	private TasklaunchrequestTransformProcessorProperties processorProperties;
 
-	@StreamListener(Processor.INPUT)
-	@SendTo(Processor.OUTPUT)
-	public Object setupRequest(String data) throws Exception{
+//	@StreamListener(Processor.INPUT)
+//	@SendTo(Processor.OUTPUT)
+	@ServiceActivator(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+	public Object setupRequest(Message<?> data) throws Exception{
 		Map<String, String> properties = new HashMap<String, String>();
 		Map<String, String> deploymentProperties = null;
 		List<String> commandLineArgs = null;

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
@@ -29,9 +29,6 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.task.launcher.TaskLaunchRequest;
 import org.springframework.integration.annotation.Transformer;
-import org.springframework.integration.support.MessageBuilder;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -61,7 +58,7 @@ public class TasklaunchrequestTransformProcessorConfiguration {
 	private TasklaunchrequestTransformProcessorProperties processorProperties;
 
 	@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
-	public Object setupRequest(Message<?> message) throws Exception{
+	public Object setupRequest(String data) throws Exception{
 		Map<String, String> properties = new HashMap<String, String>();
 		Map<String, String> deploymentProperties = null;
 		List<String> commandLineArgs = null;
@@ -99,10 +96,7 @@ public class TasklaunchrequestTransformProcessorConfiguration {
 				deploymentProperties,
 				applicationName);
 
-		Message messageResponse = MessageBuilder.withPayload(request).
-				copyHeaders(message.getHeaders()).
-				removeHeader(MessageHeaders.CONTENT_TYPE).build();
-		return messageResponse;
+		return request;
 	}
 
 	/**

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
@@ -60,9 +60,8 @@ public class TasklaunchrequestTransformProcessorConfiguration {
 	@Autowired
 	private TasklaunchrequestTransformProcessorProperties processorProperties;
 
-//	@StreamListener(Processor.INPUT)
-//	@SendTo(Processor.OUTPUT)
-	@ServiceActivator(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+	@StreamListener(Processor.INPUT)
+	@SendTo(Processor.OUTPUT)
 	public Object setupRequest(Message<?> data) throws Exception{
 		Map<String, String> properties = new HashMap<String, String>();
 		Map<String, String> deploymentProperties = null;

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
@@ -99,7 +99,7 @@ public class TasklaunchrequestTransformProcessorConfiguration {
 				deploymentProperties,
 				applicationName);
 		Map<String, Object> headerMap = new HashMap<>(message.getHeaders());
-		headerMap.put("contentType", "application/json");
+		headerMap.remove("contentType");
 		MessageHeaders messageHeaders = new MessageHeaders(headerMap);
 		Message messageResponse = MessageBuilder.withPayload(request).
 				copyHeaders(messageHeaders).build();

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorConfiguration.java
@@ -98,11 +98,10 @@ public class TasklaunchrequestTransformProcessorConfiguration {
 				properties,
 				deploymentProperties,
 				applicationName);
-		Map<String, Object> headerMap = new HashMap<>(message.getHeaders());
-		headerMap.remove("contentType");
-		MessageHeaders messageHeaders = new MessageHeaders(headerMap);
+
 		Message messageResponse = MessageBuilder.withPayload(request).
-				copyHeaders(messageHeaders).build();
+				copyHeaders(message.getHeaders()).
+				removeHeader(MessageHeaders.CONTENT_TYPE).build();
 		return messageResponse;
 	}
 

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorProperties.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorProperties.java
@@ -55,6 +55,12 @@ public class TasklaunchrequestTransformProcessorProperties {
 	private String commandLineArguments;
 
 	/**
+	 * Comma delimited list of environment properties to be applied to the
+	 * TaskLaunchRequest.
+	 */
+	private String environmentProperties;
+
+	/**
 	 * Comma delimited list of deployment properties to be applied to the
 	 * TaskLaunchRequest.
 	 */
@@ -127,5 +133,13 @@ public class TasklaunchrequestTransformProcessorProperties {
 
 	public void setApplicationName(String applicationName) {
 		this.applicationName = applicationName;
+	}
+
+	public String getEnvironmentProperties() {
+		return environmentProperties;
+	}
+
+	public void setEnvironmentProperties(String environmentProperties) {
+		this.environmentProperties = environmentProperties;
 	}
 }

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorProperties.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/main/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorProperties.java
@@ -21,7 +21,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * @author Glenn Renfro
  */
-@ConfigurationProperties
+@ConfigurationProperties("task.launch.request")
 public class TasklaunchrequestTransformProcessorProperties {
 	/**
 	 * The uri of the artifact to be applied to the TaskLaunchRequest.

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,12 @@
 
 package org.springframework.cloud.stream.app.tasklaunchrequest.transform.processor;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,6 +36,11 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
 
 /**
  * Tests for TasklaunchrequestTransformIntegrationProcessor.
@@ -63,6 +64,8 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	@Autowired
 	protected MessageCollector collector;
 
+	protected ObjectMapper objectMapper = new ObjectMapper();
+
 	/**
 	 * Validates that the app loads with default properties.
 	 */
@@ -71,13 +74,22 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 			TasklaunchrequestTransformProcessorIntegrationTests {
 
 		@Test
-		public void test() throws InterruptedException {
+		public void test() throws Exception {
 			channels.input().send(new GenericMessage<Object>("hello"));
 			channels.input().send(new GenericMessage<Object>("hello world"));
 			channels.input().send(new GenericMessage<Object>("hi!"));
-			assertThat(collector.forChannel(channels.output()), receivesPayloadThat(is(getDefaultRequest())));
-			assertThat(collector.forChannel(channels.output()), receivesPayloadThat(is(getDefaultRequest())));
-			assertThat(collector.forChannel(channels.output()), receivesPayloadThat(is(getDefaultRequest())));
+			validateDefault((String) collector.forChannel(channels.output()).take().getPayload());
+			validateDefault((String) collector.forChannel(channels.output()).take().getPayload());
+			validateDefault((String) collector.forChannel(channels.output()).take().getPayload());
+		}
+
+		private void validateDefault(String result) throws Exception{
+			TaskLaunchRequest tlr = this.objectMapper.readValue(result, TaskLaunchRequest.class);
+			assertThat(tlr.getApplicationName()).startsWith("Task-");
+			assertThat(tlr.getUri()).isEqualTo(DEFAULT_URI);
+			assertThat(tlr.getCommandlineArguments().size()).isEqualTo(0);
+			assertThat(tlr.getEnvironmentProperties().size()).isEqualTo(0);
+			assertThat(tlr.getDeploymentProperties().size()).isEqualTo(0);
 		}
 	}
 
@@ -96,12 +108,12 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	/**
 	 * Validates that the app handles empty payload.
 	 */
-	@TestPropertySource(properties = "uri=" + DEFAULT_URI)
+	@TestPropertySource(properties = {"uri=" + DEFAULT_URI, "applicationName=test"})
 	public static class UsingEmptyPayloadIntegrationTests extends
 			TasklaunchrequestTransformProcessorIntegrationTests {
 
 		@Test()
-		public void test() throws InterruptedException {
+		public void test() throws Exception {
 			channels.input().send(new GenericMessage<Object>(""));
 			assertThat(collector.forChannel(channels.output()),
 					receivesPayloadThat(is(getDefaultRequest())));
@@ -116,12 +128,12 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 			"dataSourceUserName=myUserName",
 			"dataSourceDriverClassName=myClassName",
 			"uri=" + DEFAULT_URI,
-	        "applicationName=fooTest"})
+	        "applicationName=test"})
 	public static class UsingDataSourceIntegrationTests
 			extends TasklaunchrequestTransformProcessorIntegrationTests {
 
 		@Test
-		public void testDataSources() throws InterruptedException {
+		public void testDataSources() throws Exception {
 			channels.input().send(new GenericMessage<Object>("hello"));
 			Map<String, String> environmentVariables = new HashMap<>(4);
 			environmentVariables.put("spring_datasource_url", "myUrl");
@@ -134,10 +146,12 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 		}
 
 		@Test
-		public void testForApplicationName() throws InterruptedException {
+		public void testForApplicationName() throws Exception {
 			channels.input().send(new GenericMessage<Object>("hello"));
-			TaskLaunchRequest result = (TaskLaunchRequest) collector.forChannel(channels.output()).take().getPayload();
-			assertThat(result.getApplicationName(), is(equalTo("fooTest")));
+			TaskLaunchRequest result = objectMapper.readValue(
+					(String) collector.forChannel(channels.output()).take().
+							getPayload(), TaskLaunchRequest.class);
+			assertThat(result.getApplicationName()).isEqualTo("test");
 		}
 	}
 
@@ -146,24 +160,32 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	 */
 	@TestPropertySource(properties = {
 			"deploymentProperties=app.wow.hello=world,app.wow.foo=bar,app.wow.test=a=b,c=d,e=\"baz=bbb,nnn=mmm\"",
-			"uri=" + DEFAULT_URI })
+			"environmentProperties=app.wow.hello2=world2,app.wow.foo2=bar2,app.wow.test2=a=b2,c2=d2,e2=\"baz=bbb,nnn=mmm2\"",
+			"uri=" + DEFAULT_URI,
+			"applicationName=test"})
 	public static class UsingDeploymentPropertiesIntegrationTests
 			extends TasklaunchrequestTransformProcessorIntegrationTests {
 
 		@Test
-		public void test() throws InterruptedException {
+		public void test() throws Exception {
 			channels.input().send(new GenericMessage<Object>("hello"));
-			Map<String, String> environmentVariables = new HashMap<>(3);
-			Map<String, String> deploymentProperties = new HashMap<>(2);
-			deploymentProperties.put("app.wow.hello", "world");
-			deploymentProperties.put("app.wow.foo", "bar");
-			deploymentProperties.put("app.wow.test", "a=b");
-			deploymentProperties.put("c", "d");
-			deploymentProperties.put("e", "\"baz=bbb,nnn=mmm\"");
-
-			assertThat(collector.forChannel(channels.output()),
-					receivesPayloadThat(is(getDefaultRequest(
-							environmentVariables, deploymentProperties, null))));
+			String result = (String) collector.forChannel(channels.output()).take().getPayload();
+			TaskLaunchRequest tlr = this.objectMapper.readValue(result, TaskLaunchRequest.class);
+			assertThat(tlr.getDeploymentProperties().get("c")).isEqualTo("d");
+			assertThat(tlr.getDeploymentProperties().get("app.wow.hello")).isEqualTo("world");
+			assertThat(tlr.getDeploymentProperties().get("app.wow.foo")).isEqualTo("bar");
+			assertThat(tlr.getDeploymentProperties().get("app.wow.test")).isEqualTo("a=b");
+			assertThat(tlr.getDeploymentProperties().get("e")).isEqualTo("\"baz=bbb,nnn=mmm\"");
+			assertThat(tlr.getEnvironmentProperties().get("c2")).isEqualTo("d2");
+			assertThat(tlr.getEnvironmentProperties().get("app.wow.hello2")).isEqualTo("world2");
+			assertThat(tlr.getEnvironmentProperties().get("app.wow.foo2")).isEqualTo("bar2");
+			assertThat(tlr.getEnvironmentProperties().get("app.wow.test2")).isEqualTo("a=b2");
+			assertThat(tlr.getEnvironmentProperties().get("e2")).isEqualTo("\"baz=bbb,nnn=mmm2\"");
+			assertThat(tlr.getApplicationName()).isEqualTo("test");
+			assertThat(tlr.getUri()).isEqualTo(DEFAULT_URI);
+			assertThat(tlr.getDeploymentProperties().size()).isEqualTo(5);
+			assertThat(tlr.getEnvironmentProperties().size()).isEqualTo(5);
+			assertThat(tlr.getCommandlineArguments().size()).isEqualTo(0);
 		}
 	}
 
@@ -172,12 +194,13 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	 */
 	@TestPropertySource(properties = {
 			"commandLineArguments=--hello=world --foo=bar",
-			"uri=" + DEFAULT_URI })
+			"uri=" + DEFAULT_URI,
+			"applicationName=test" })
 	public static class UsingCommandLineArgsIntegrationTests
 			extends TasklaunchrequestTransformProcessorIntegrationTests {
 
 		@Test
-		public void test() throws InterruptedException {
+		public void test() throws Exception {
 			channels.input().send(new GenericMessage<Object>("hello"));
 			Map<String, String> environmentVariables = new HashMap<>(1);
 			List<String> commandLineArgs = new ArrayList<>(2);
@@ -189,22 +212,22 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 		}
 	}
 
-	protected TaskLaunchRequest getDefaultRequest() {
+	protected String getDefaultRequest() throws Exception{
 		Map<String, String> environmentVariables = new HashMap<>(1);
 		return getDefaultRequest(environmentVariables, null, null);
 	}
 
-	protected TaskLaunchRequest getDefaultRequest(
+	protected String getDefaultRequest(
 			Map<String, String> environmentVariables,
 			Map<String, String> deploymentProperties,
-			List<String> commandLineArgs) {
+			List<String> commandLineArgs) throws Exception{
 		TaskLaunchRequest request = new TaskLaunchRequest(
 				DEFAULT_URI,
 				commandLineArgs,
 				environmentVariables,
 				deploymentProperties,
 				"test");
-		return request;
+		return objectMapper.writeValueAsString(request);
 	}
 
 	@SpringBootApplication

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
@@ -31,7 +31,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.cloud.task.launcher.TaskLaunchRequest;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.transformer.MessageTransformationException;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
@@ -81,6 +84,14 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 			validateDefault((String) collector.forChannel(channels.output()).take().getPayload());
 			validateDefault((String) collector.forChannel(channels.output()).take().getPayload());
 			validateDefault((String) collector.forChannel(channels.output()).take().getPayload());
+		}
+
+		@Test
+		public void testHeaderContentTypeProperlySet() throws Exception {
+			Message<?> message = MessageBuilder.withPayload("hello").setHeader(MessageHeaders.CONTENT_TYPE, "text/plain").build();
+			channels.input().send(message);
+			Message<?> outputMessage = collector.forChannel(channels.output()).take();
+			assertThat(outputMessage.getHeaders().get(MessageHeaders.CONTENT_TYPE)).isEqualTo("application/json");
 		}
 
 		private void validateDefault(String result) throws Exception{

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
@@ -31,10 +31,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.cloud.task.launcher.TaskLaunchRequest;
+import org.springframework.http.MediaType;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.transformer.MessageTransformationException;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
@@ -91,7 +94,7 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 			Message<?> message = MessageBuilder.withPayload("hello").setHeader(MessageHeaders.CONTENT_TYPE, "text/plain").build();
 			channels.input().send(message);
 			Message<?> outputMessage = collector.forChannel(channels.output()).take();
-			assertThat(outputMessage.getHeaders().get(MessageHeaders.CONTENT_TYPE)).isEqualTo("application/json");
+			assertThat(outputMessage.getHeaders().get(MessageHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
 		}
 
 		private void validateDefault(String result) throws Exception{
@@ -110,11 +113,12 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	public static class UsingNoURIIntegrationTests extends
 			TasklaunchrequestTransformProcessorIntegrationTests {
 
-		@Test(expected = MessageTransformationException.class)
+		@Test(expected = MessagingException.class)
 		public void test() throws InterruptedException {
 			channels.input().send(new GenericMessage<Object>("hello"));
 		}
 	}
+
 
 	/**
 	 * Validates that the app handles empty payload.
@@ -123,7 +127,7 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	public static class UsingEmptyPayloadIntegrationTests extends
 			TasklaunchrequestTransformProcessorIntegrationTests {
 
-		@Test()
+		@Test(expected = MethodArgumentNotValidException.class)
 		public void test() throws Exception {
 			channels.input().send(new GenericMessage<Object>(""));
 			assertThat(collector.forChannel(channels.output()),

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
@@ -127,7 +127,7 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	public static class UsingEmptyPayloadIntegrationTests extends
 			TasklaunchrequestTransformProcessorIntegrationTests {
 
-		@Test(expected = MethodArgumentNotValidException.class)
+		@Test()
 		public void test() throws Exception {
 			channels.input().send(new GenericMessage<Object>(""));
 			assertThat(collector.forChannel(channels.output()),

--- a/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-tasklaunchrequest-transform/src/test/java/org/springframework/cloud/stream/app/tasklaunchrequest/transform/processor/TasklaunchrequestTransformProcessorIntegrationTests.java
@@ -75,7 +75,7 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	/**
 	 * Validates that the app loads with default properties.
 	 */
-	@TestPropertySource(properties = "uri=" + DEFAULT_URI)
+	@TestPropertySource(properties = "task.launch.request.uri=" + DEFAULT_URI)
 	public static class UsingDefaultIntegrationTests extends
 			TasklaunchrequestTransformProcessorIntegrationTests {
 
@@ -123,7 +123,7 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	/**
 	 * Validates that the app handles empty payload.
 	 */
-	@TestPropertySource(properties = {"uri=" + DEFAULT_URI, "applicationName=test"})
+	@TestPropertySource(properties = {"task.launch.request.uri=" + DEFAULT_URI, "task.launch.request.applicationName=test"})
 	public static class UsingEmptyPayloadIntegrationTests extends
 			TasklaunchrequestTransformProcessorIntegrationTests {
 
@@ -138,12 +138,12 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	/**
 	 * Verify datasource properties are added to the TaskLaunchRequest.
 	 */
-	@TestPropertySource(properties = { "dataSourceUrl=myUrl",
-			"dataSourcePassword=myPassword",
-			"dataSourceUserName=myUserName",
-			"dataSourceDriverClassName=myClassName",
-			"uri=" + DEFAULT_URI,
-	        "applicationName=test"})
+	@TestPropertySource(properties = { "task.launch.request.dataSourceUrl=myUrl",
+			"task.launch.request.dataSourcePassword=myPassword",
+			"task.launch.request.dataSourceUserName=myUserName",
+			"task.launch.request.dataSourceDriverClassName=myClassName",
+			"task.launch.request.uri=" + DEFAULT_URI,
+	        "task.launch.request.applicationName=test"})
 	public static class UsingDataSourceIntegrationTests
 			extends TasklaunchrequestTransformProcessorIntegrationTests {
 
@@ -174,10 +174,10 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	 * Verify deploymentProperties are added to the TaskLaunchRequest.
 	 */
 	@TestPropertySource(properties = {
-			"deploymentProperties=app.wow.hello=world,app.wow.foo=bar,app.wow.test=a=b,c=d,e=\"baz=bbb,nnn=mmm\"",
-			"environmentProperties=app.wow.hello2=world2,app.wow.foo2=bar2,app.wow.test2=a=b2,c2=d2,e2=\"baz=bbb,nnn=mmm2\"",
-			"uri=" + DEFAULT_URI,
-			"applicationName=test"})
+			"task.launch.request.deploymentProperties=app.wow.hello=world,app.wow.foo=bar,app.wow.test=a=b,c=d,e=\"baz=bbb,nnn=mmm\"",
+			"task.launch.request.environmentProperties=app.wow.hello2=world2,app.wow.foo2=bar2,app.wow.test2=a=b2,c2=d2,e2=\"baz=bbb,nnn=mmm2\"",
+			"task.launch.request.uri=" + DEFAULT_URI,
+			"task.launch.request.applicationName=test"})
 	public static class UsingDeploymentPropertiesIntegrationTests
 			extends TasklaunchrequestTransformProcessorIntegrationTests {
 
@@ -208,9 +208,9 @@ public abstract class TasklaunchrequestTransformProcessorIntegrationTests {
 	 *  Verify commandLineArguments are added to the TaskLaunchRequest.
 	 */
 	@TestPropertySource(properties = {
-			"commandLineArguments=--hello=world --foo=bar",
-			"uri=" + DEFAULT_URI,
-			"applicationName=test" })
+			"task.launch.request.commandLineArguments=--hello=world --foo=bar",
+			"task.launch.request.uri=" + DEFAULT_URI,
+			"task.launch.request.applicationName=test" })
 	public static class UsingCommandLineArgsIntegrationTests
 			extends TasklaunchrequestTransformProcessorIntegrationTests {
 

--- a/tasklaunchrequest-transform-app-dependencies/pom.xml
+++ b/tasklaunchrequest-transform-app-dependencies/pom.xml
@@ -18,7 +18,7 @@
 	</parent>
 
 	<properties>
-		<spring.cloud.task.version>1.1.2.RELEASE</spring.cloud.task.version>
+		<spring.cloud.task.version>2.0.0.BUILD-SNAPSHOT</spring.cloud.task.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
* Updated task dependencies so that they will work with new Task-Stream 2.0 SNAPSHOT
* Now sets content type to application/json so downstream users won't have to set content type for task launchers.

resolves #7

